### PR TITLE
Add an intrusive pointer implementation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,12 +61,12 @@ smv_remote_whitelist = "^origin$"
 #
 html_theme = 'furo'
 html_theme_options = {
-    "light_css_variables": {
-        "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-    },
-    "dark_css_variables": {
-        "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-    },
+    # "light_css_variables": {
+    #     "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
+    # },
+    # "dark_css_variables": {
+    #     "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
+    # },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,9 @@
    :caption: Contents:
 
    modules/concepts.rst
-   modules/misc.rst
+   modules/intrusive_ptr.rst
    modules/math_supplement.rst
+   modules/misc.rst
    modules/overloaded.rst
    modules/pack_utils.rst
    modules/scope_guard.rst

--- a/docs/modules/intrusive_ptr.rst
+++ b/docs/modules/intrusive_ptr.rst
@@ -1,0 +1,353 @@
+
+===============
+ intrusive_ptr
+===============
+
+::
+
+    #include <dplx/cncr/intrusive_ptr.hpp>
+    namespace dplx::cncr {}
+
+.. namespace:: dplx::cncr
+
+
+concepts
+--------
+
+.. concept:: template <typename RC> \
+             ref_counted
+
+    A type whose lifetime is managed by an internal reference counter and which
+    has a :class:`reference_counted_traits <template<typename RC> reference_counted_traits>` 
+    specialization for controlling the reference counter. 
+    
+    All functions are required to be ``noexcept``.
+
+    **Notation**
+
+    .. var:: RC &obj
+
+        An lvalue reference to a reference counted object.
+
+    **Valid Expressions**
+
+    - :expr:`reference_counted_traits<RC>::counter_type` is the underlying
+      integer type or void if unknown.
+    - :expr:`reference_counted_traits<RC>::add_reference(obj)` increments 
+      :expr:`obj`'s reference count by one.
+    - :expr:`reference_counted_traits<RC>::release(obj)` decrements
+      :expr:`obj`'s reference count by one and atomically destructs it if the
+      reference count reached zero.
+
+.. concept:: template <typename RC> inspectable_ref_counted
+
+    Requires that a :concept:`ref_counted <template<typename RC> ref_counted>` 
+    type also provides a way to get an estimate of the current reference count.
+    Not requiring the value to be excact allows reference counted objects 
+    shared across multiple threads to satisfy this.
+
+    The only value required to be stable is ``1`` in which case our thread
+    should be the only pointee. (With the exception of insane software 
+    architectures which retain non owning across threads).
+
+    All functions are required to be ``noexcept``.
+
+    **Notation**
+
+    .. var:: RC &obj
+
+        An lvalue reference to a reference counted object.
+
+    **Valid Expressions**
+
+    - :expr:`reference_counted_traits<RC>::counter_type` is the underlying
+      integer type.
+    - :expr:`reference_counted_traits<RC>::reference_count(obj)` returns an 
+      (estimate) of the current counter value of type ``counter_type``.
+
+.. concept:: template <ref_counted RC> detail::dplx_ref_counted
+
+    *Exposition Only*
+
+    Describes the typical deeplex reference counting API.
+
+    All functions are required to be ``noexcept``.
+
+    **Notation**
+
+    .. var:: RC const &obj
+
+        An lvalue reference to a reference counted object.
+
+    **Valid Expressions**
+
+    - :expr:`obj.add_reference()` increments the reference counter.
+    - :expr:`obj.release()` decrements the reference counter.
+    - :expr:`obj.reference_count()` retrieves the current (approximate) 
+      reference count.
+
+customization points
+--------------------
+
+.. class:: template <typename RC> \
+           reference_counted_traits
+
+    This is a customization point i.e. there is no primary template definition.
+
+    The implementation requirements are described by the :concept:`ref_counted`
+    and :concept:`inspectable_ref_counted` concepts.
+
+.. class:: template <detail::dplx_ref_counted RC> \
+           reference_counted_traits<RC>
+
+    The specialization of :class:`reference_counted_traits <dplx::cncr::reference_counted_traits>`
+    for types satisfying :concept:`detail::dplx_ref_counted`.
+
+    The specialization satisfies :concept:`inspectable_ref_counted`.
+
+
+factory functions
+-----------------
+
+.. function:: template <ref_counted RC> \
+              constexpr auto intrusive_ptr_import(RC *obj) -> intrusive_ptr<RC>
+
+    Creates a :expr:`intrusive_ptr<RC>` tracking :expr:`obj` assuming ownership 
+    of an existing reference (i.e. it doesn't call ``add_reference()``)
+
+    It is a type deducing wrapper around :expr:`intrusive_ptr<RC>::import`.
+
+.. function:: template <ref_counted RC> \
+              constexpr auto intrusive_ptr_acquire(RC *obj) -> intrusive_ptr<RC>
+
+    Creates a :expr:`intrusive_ptr<RC>` tracking :expr:`obj` assuming ownership 
+    by acquiring a new reference (i.e. it calls ``add_reference()``).
+
+    It is a type deducing wrapper around :expr:`intrusive_ptr<RC>::acquire`.
+
+
+types
+-----
+
+.. class:: template <ref_counted RC> \
+           intrusive_ptr<RC, RC>
+
+    The usual intrusive smart pointer which poses as a pointer to the object
+    whose lifetime it manages.
+
+    The type satisfies `std::regular <https://en.cppreference.com/w/cpp/concepts/regular>`_,
+    i.e. it is default initializable, copyable and equality comparable.
+    It is also swappable, totally ordered and contextually convertible to bool.
+
+    Additionally the following members exist:
+
+    .. type:: element_type = RC
+
+        Exposes the type parameter for meta programming purposes.
+
+    .. type:: handle_type = intrusive_ptr<RC>
+
+        Exposes the type which is used for reference counting. It is exposed for
+        compatibility with the aliasing variant :class:`intrusive_ptr\<T, RC> <template <typename T, ref_counted RC> dplx::cncr::intrusive_ptr>`
+        whose :expr:`element_type` is not equal to :expr:`RC`.
+
+    .. function:: constexpr intrusive_ptr(std::nullptr_t) noexcept
+
+        Constructs an empty instance from a :expr:`nullptr` literal which makes
+        the following expressions well formed:
+
+        ::
+
+            intrusive_ptr<T> ptr{nullptr};
+            ptr = nullptr;
+
+    .. function:: template<ref_counted U> \
+                  constexpr intrusive_ptr(intrusive_ptr<U> &&other) noexcept
+
+        Imports ownership from a compatible :expr:`intrusive_ptr<U>` instance.
+
+        This constructor is only available if 
+        :expr:`std::convertible_to<U *, RC *>` holds.
+
+    .. function:: template<ref_counted U> \
+                  constexpr intrusive_ptr(intrusive_ptr<U> const &other) noexcept
+
+        Aquires ownership from a compatible :expr:`intrusive_ptr<U>` instance.
+
+        This constructor is only available if 
+        :expr:`std::convertible_to<U *, RC *>` holds.
+
+    .. function:: static constexpr auto import(RC *ptr) noexcept -> intrusive_ptr<RC>
+
+        Creates a :expr:`intrusive_ptr<RC>` tracking :expr:`ptr` assuming ownership of
+        an existing reference (i.e. it doesn't call ``add_reference()``).
+
+    .. function:: static constexpr auto acquire(RC *ptr) noexcept -> intrusive_ptr<RC>
+
+        Creates a :expr:`intrusive_ptr<RC>` tracking :expr:`ptr` assuming ownership by
+        acquiring a new reference (i.e. it calls ``add_reference()``).
+
+    .. function:: constexpr auto get() const noexcept -> RC *
+
+        Retrieves the stored object pointer.
+
+    .. function:: constexpr auto get_handle() const noexcept -> intrusive_ptr<RC>
+
+        Returns a copy of ``this``. It is exposed for compatibility with the
+        aliasing variant :class:`intrusive_ptr\<T, RC> <template <typename T, ref_counted RC> dplx::cncr::intrusive_ptr>`
+        whose :expr:`element_type` is not equal to :expr:`RC`.
+
+    .. function:: constexpr auto use_count() const noexcept -> reference_counted_traits<RC>::counter_type
+    .. function:: constexpr auto reference_count() const noexcept -> reference_counted_traits<RC>::counter_type
+
+        If :expr:`RC` satisfies :concept:`inspectable_ref_counted` it returns the
+        (approximate) number of references. The only value guaranteed to be stable
+        in multi-threaded environments is ``1``.
+
+        The :func:`use_count` name exists for API compatibility with 
+        ``std::shared_ptr``.
+
+    .. function:: constexpr auto release() noexcept -> RC *
+
+        Returns the bound object after unbinding ``this`` without decrementing
+        the reference counter.
+
+    .. function::  constexpr void reset(RC *toBeBound) noexcept
+
+        Replaces the managed object with :expr:`toBeBound` and increases its ref
+        count.
+
+.. class:: template <> \
+           intrusive_ptr<void, void>
+
+    A type erased intrusive pointer. It keeps a pointer to a vtable in addition
+    to a `void *` referencing the bound object.
+
+    The type satisfies `std::regular <https://en.cppreference.com/w/cpp/concepts/regular>`_,
+    i.e. it is default initializable, copyable and equality comparable.
+    It is also swappable, totally ordered and contextually convertible to bool.
+
+    You can either (copy) assign normal intrusive pointer instances or use the
+    static class functions :func:`import <template<ref_counted RC> import>` or
+    :func:`acquire <template<ref_counted RC> acquire>`
+
+    Additionally the following members exist:
+
+    .. type:: element_type = void
+
+        Exposes the type parameter for meta programming purposes.
+
+    .. type:: handle_type = intrusive_ptr<void, void>
+
+        Exposes the type which is used for reference counting. It is exposed for
+        compatibility with the aliasing variant :class:`intrusive_ptr\<T, RC> <template <typename T, ref_counted RC> dplx::cncr::intrusive_ptr>`
+        whose :expr:`element_type` is not equal to :expr:`void`.
+
+    .. function:: intrusive_ptr(std::nullptr_t) noexcept
+
+        Constructs an empty instance from a :expr:`nullptr` literal which makes
+        the following expressions well formed:
+
+        ::
+
+            intrusive_ptr<void> ptr{nullptr};
+            ptr = nullptr;
+
+    .. function:: template <ref_counted U> intrusive_ptr(intrusive_ptr<U> &&other) noexcept
+
+        Imports ownership from an :expr:`intrusive_ptr<U>` instance.
+
+    .. function:: template <ref_counted U> intrusive_ptr(intrusive_ptr<U> const &other) noexcept
+
+        Aquires ownership from an :expr:`intrusive_ptr<U>` instance.
+
+    .. function:: template <ref_counted RC> static auto import(RC *ptr) noexcept -> intrusive_ptr<void, void>
+
+        Creates a :expr:`intrusive_ptr<void, void>` tracking :expr:`ptr` 
+        assuming ownership of an existing reference (i.e. it doesn't call 
+        ``add_reference()``).
+
+    .. function:: template <ref_counted RC> static auto acquire(RC *ptr) noexcept -> intrusive_ptr<void, void>
+
+        Creates a :expr:`intrusive_ptr<void, void>` tracking :expr:`ptr` 
+        assuming ownership by acquiring a new reference (i.e. it calls 
+        ``add_reference()``).
+
+    .. function:: auto get() const noexcept -> void *
+
+        Retrieves the stored object pointer.
+
+    .. function:: auto get_handle() const noexcept -> intrusive_ptr<void>
+
+        Returns a copy of ``this``. It is exposed for compatibility with the
+        aliasing variant :class:`intrusive_ptr\<T, RC> <template <typename T, ref_counted RC> dplx::cncr::intrusive_ptr>`
+        whose :expr:`element_type` is not equal to :expr:`void`.
+
+    .. function:: template <ref_counted U> auto release_as() noexcept -> U *
+
+        Returns the bound object pointer after casting it to :expr:`U` after
+        unbinding ``this`` without decrementing the reference counter.
+
+.. class:: template <typename T, ref_counted RC = T> \
+           intrusive_ptr
+
+    The main template is an aliasing intrusive pointer which means it poses as
+    a pointer to an object of type :expr:`T` while managing the reference count
+    of (a potentially different) object of type :expr:`RC`.
+
+    The type satisfies `std::regular <https://en.cppreference.com/w/cpp/concepts/regular>`_,
+    i.e. it is default initializable, copyable and equality comparable.
+    It is also swappable, totally ordered and contextually convertible to bool.
+
+    Additionally the following members exist:
+
+    .. type:: element_type = T
+
+        Exposes the type parameter for meta programming purposes.
+
+    .. type:: handle_type = intrusive_ptr<RC>
+
+        Exposes the intrusive pointer type which implements reference counting.
+
+    .. function:: constexpr intrusive_ptr(std::nullptr_t) noexcept
+
+        Constructs an empty instance from a :expr:`nullptr` literal which makes
+        the following expressions well formed:
+
+        ::
+
+            intrusive_ptr<T, RC> ptr{nullptr};
+            ptr = nullptr;
+
+    .. function:: constexpr intrusive_ptr(intrusive_ptr<RC> &&handle, T *ptr) noexcept
+
+        Creates a :expr:`intrusive_ptr<T, RC>` tracking :expr:`handle` assuming ownership of
+        an existing reference (i.e. it doesn't call ``add_reference()``).
+
+        The constructed intrusive pointer poses as :expr:`ptr` afterwards.
+
+    .. function:: constexpr intrusive_ptr(intrusive_ptr<RC> const &handle, T *ptr) noexcept
+
+        Creates a :expr:`intrusive_ptr<T, RC>` tracking :expr:`handle` assuming ownership by
+        acquiring a new reference (i.e. it calls ``add_reference()``).
+
+        The constructed intrusive pointer poses as :expr:`ptr` afterwards.
+
+    .. function:: constexpr auto get() const noexcept -> T *
+
+        Retrieves the stored aliased object pointer.
+
+    .. function:: constexpr auto get_handle() const noexcept -> intrusive_ptr<RC>
+
+        Returns a copy of the contained object handle.
+
+    .. function:: constexpr auto use_count() const noexcept -> reference_counted_traits<RC>::counter_type
+    .. function:: constexpr auto reference_count() const noexcept -> reference_counted_traits<RC>::counter_type
+
+        If :expr:`RC` satisfies :concept:`inspectable_ref_counted` it returns the
+        (approximate) number of references. The only value guaranteed to be stable
+        in multi-threaded environments is ``1``.
+
+        The :func:`use_count` name exists for API compatibility with 
+        ``std::shared_ptr``.
+

--- a/sources.cmake
+++ b/sources.cmake
@@ -1,5 +1,6 @@
 set(_SOURCES
     cncr/concepts.hpp
+    cncr/intrusive_ptr.hpp
     cncr/math_supplement.hpp
     cncr/misc.hpp
     cncr/mp_lite.hpp

--- a/src/dplx/cncr.natvis
+++ b/src/dplx/cncr.natvis
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="dplx::cncr::intrusive_ptr&lt;void,void&gt;">
+        <DisplayString Condition="mPtr != 0">{mPtr} {{ vtable = {mVTable} }}</DisplayString>
+        <DisplayString Condition="mPtr == 0">nullptr</DisplayString>
+        <Expand HideRawView="true">
+            <Item Name="[handle]" Condition="mPtr != 0">mPtr</Item>
+            <Item Name="[vtable]" Condition="mPtr != 0">mVTable</Item>
+        </Expand>
+    </Type>
+    <Type Name="dplx::cncr::intrusive_ptr&lt;*,*&gt;" Priority="MediumLow">
+        <SmartPointer Usage="Minimal">mPtr</SmartPointer>
+    </Type>
+    <Type Name="dplx::cncr::intrusive_ptr&lt;*,*&gt;">
+        <SmartPointer Usage="Minimal">mPtr</SmartPointer>
+        <DisplayString Condition="mHandle.mPtr == 0">nullptr</DisplayString>
+        <Expand HideRawView="true">
+            <Item Name="[ptr]">mPtr</Item>
+            <Item Name="[handle]">mHandle</Item>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/src/dplx/cncr/intrusive_ptr.hpp
+++ b/src/dplx/cncr/intrusive_ptr.hpp
@@ -1,0 +1,664 @@
+
+// Copyright Henrik Steffen Gaßmann 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <concepts>
+#include <utility>
+
+namespace dplx::cncr
+{
+
+template <typename T, typename = void>
+struct reference_counted_traits;
+
+// clang-format off
+template <typename RC>
+concept ref_counted = requires(RC &v)
+{
+    typename reference_counted_traits<RC>;
+    typename reference_counted_traits<RC>::counter_type;
+    { reference_counted_traits<RC>::add_reference(v) } noexcept;
+    { reference_counted_traits<RC>::release(v) } noexcept;
+};
+// clang-format on
+
+// clang-format off
+template <typename RC>
+concept inspectable_ref_counted = ref_counted<RC> && requires(RC &v)
+{
+    typename reference_counted_traits<RC>::counter_type;
+    { reference_counted_traits<RC>::reference_count(v) } noexcept
+        -> std::same_as<typename reference_counted_traits<RC>::counter_type>;
+};
+// clang-format on
+
+namespace detail
+{
+
+    // clang-format off
+template <typename RC>
+concept dplx_ref_counted = requires(RC const &obj)
+{
+    { obj.add_reference() } noexcept;
+    { obj.release() } noexcept;
+    { obj.reference_count() } noexcept;
+};
+    // clang-format on
+
+} // namespace detail
+
+template <detail::dplx_ref_counted RC>
+struct reference_counted_traits<RC>
+{
+    using counter_type = decltype(std::declval<RC &>().reference_count());
+
+    static constexpr void add_reference(RC &v) noexcept
+    {
+        v.add_reference();
+    }
+    static constexpr void release(RC &v) noexcept
+    {
+        v.release();
+    }
+
+    static constexpr auto reference_count(RC &v) noexcept
+    {
+        return v.reference_count();
+    }
+};
+
+namespace detail
+{
+
+template <ref_counted RC>
+struct erased_ref_ops final
+{
+    using traits = reference_counted_traits<RC>;
+
+    static void add_reference(void *h) noexcept
+    {
+        traits::add_reference(*static_cast<RC *>(h));
+    }
+    static void release(void *h) noexcept
+    {
+        traits::release(*static_cast<RC *>(h));
+    }
+};
+
+struct ref_ops_vtable final
+{
+    using op_fn = void (*)(void *) noexcept;
+
+    op_fn add_reference;
+    op_fn release;
+};
+
+template <typename RC>
+inline constexpr ref_ops_vtable ref_ops_vtable_of{
+        &erased_ref_ops<RC>::add_reference,
+        &erased_ref_ops<RC>::release,
+};
+
+} // namespace detail
+
+template <typename T, typename RC = T>
+    requires std::same_as<RC, void> || ref_counted<RC>
+class intrusive_ptr;
+
+constexpr inline struct intrusive_ptr_import_fn
+{
+    template <ref_counted RC>
+    auto operator()(RC *referenceCounted) const noexcept -> intrusive_ptr<RC>
+    {
+        return intrusive_ptr<RC>::import(referenceCounted);
+    }
+} intrusive_ptr_import{};
+
+constexpr inline struct intrusive_ptr_acquire_fn
+{
+    template <ref_counted RC>
+    auto operator()(RC *referenceCounted) const noexcept -> intrusive_ptr<RC>
+    {
+        return intrusive_ptr<RC>::acquire(referenceCounted);
+    }
+} intrusive_ptr_acquire;
+
+///
+/// @brief A smart pointer managing objects whose lifetime is governed by an
+///        internal reference counter accessible via
+///        @ref reference_counted_traits.
+///
+/// The API is drop-in compatible with std::shared_ptr except weak references.
+///
+template <typename RC>
+    requires std::same_as<RC, void> || ref_counted<RC>
+class intrusive_ptr<RC, RC> final
+{
+    using traits = reference_counted_traits<RC>;
+
+    RC *mPtr;
+
+public:
+    constexpr ~intrusive_ptr() noexcept
+    {
+        if (mPtr)
+        {
+            traits::release(*mPtr);
+        }
+    }
+    constexpr intrusive_ptr() noexcept
+        : mPtr{}
+    {
+    }
+
+    constexpr intrusive_ptr(intrusive_ptr const &other) noexcept
+        : mPtr{other.mPtr}
+    {
+        if (mPtr)
+        {
+            traits::add_reference(*mPtr);
+        }
+    }
+    constexpr auto operator=(intrusive_ptr const &other) noexcept
+            -> intrusive_ptr &
+    {
+        if (mPtr)
+        {
+            traits::release(*mPtr);
+        }
+        if (other.mPtr)
+        {
+            traits::add_reference(*other.mPtr);
+        }
+        mPtr = other.mPtr;
+        return *this;
+    }
+
+    constexpr intrusive_ptr(intrusive_ptr &&other) noexcept
+        : mPtr{std::exchange(other.mPtr, nullptr)}
+    {
+    }
+    constexpr auto operator=(intrusive_ptr &&other) noexcept -> intrusive_ptr &
+    {
+        if (mPtr)
+        {
+            traits::release(*mPtr);
+        }
+        mPtr = std::exchange(other.mPtr, nullptr);
+        return *this;
+    }
+
+    friend inline constexpr void swap(intrusive_ptr &lhs,
+                                      intrusive_ptr &rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.mPtr, rhs.mPtr);
+    }
+
+    constexpr intrusive_ptr(std::nullptr_t) noexcept
+        : mPtr{}
+    {
+    }
+
+    template <ref_counted U>
+        requires std::convertible_to<U *, RC *>
+    constexpr intrusive_ptr(intrusive_ptr<U> const &other) noexcept
+        : mPtr(other.get())
+    {
+        if (mPtr)
+        {
+            traits::add_reference(*mPtr);
+        }
+    }
+    template <ref_counted U>
+        requires std::convertible_to<U *, RC *>
+    constexpr intrusive_ptr(intrusive_ptr<U> &&other) noexcept
+        : mPtr(other.release())
+    {
+    }
+
+private:
+    explicit constexpr intrusive_ptr(RC *referenceCounted) noexcept
+        : mPtr{referenceCounted}
+    {
+    }
+
+public:
+    /// @brief Creates a intrusive_ptr tracking ptr assuming ownership of an
+    ///        existing reference (i.e. it doesn't call add_reference)
+    /// @param ptr the object to be tracked (may be a nullptr)
+    /// @return the created intrusive_ptr
+    static constexpr auto import(RC *ptr) noexcept -> intrusive_ptr
+    {
+        return intrusive_ptr(ptr);
+    }
+    /// @brief Creates a intrusive_ptr tracking ptr assuming ownership by
+    /// acquiring a
+    ///        new reference (i.e. it calls add_reference)
+    /// @param ptr the object to be tracked (may be a nullptr)
+    /// @return the created intrusive_ptr
+    static constexpr auto acquire(RC *ptr) noexcept -> intrusive_ptr
+    {
+        if (ptr)
+        {
+            traits::add_reference(*ptr);
+        }
+        return intrusive_ptr(ptr);
+    }
+
+    using element_type = RC;
+    using handle_type = intrusive_ptr;
+
+    /// @brief Returns true if an object is bound false otherwise
+    constexpr explicit operator bool() const noexcept
+    {
+        return mPtr != nullptr;
+    }
+
+    /// @brief Returns a pointer to the bound object or nullptr if empty.
+    constexpr auto get() const noexcept -> RC *
+    {
+        return mPtr;
+    }
+    constexpr auto get_handle() const noexcept -> intrusive_ptr<RC>
+    {
+        return *this;
+    }
+    constexpr auto operator*() const noexcept -> RC &
+    {
+        return *mPtr;
+    }
+    constexpr auto operator->() const noexcept -> RC *
+    {
+        return mPtr;
+    }
+
+    /// @brief If T satisfies inspectable_ref_counted it returns the
+    ///        (approximate) number of references. The only value guaranteed to
+    ///        be stable in multi-threaded environments is ``1``. This API
+    ///        behaves the same as @ref reference_count and exists for
+    ///        std::shared_ptr compatibility.
+    constexpr auto use_count() const noexcept ->
+            typename traits::counter_type requires inspectable_ref_counted<RC>
+
+    {
+        return traits::reference_count(*mPtr);
+    }
+    /// @brief If T satisfies inspectable_ref_counted it returns the
+    ///        (approximate) number of references. The only value guaranteed to
+    ///        be stable in multi-threaded environments is ``1``.
+    constexpr auto reference_count() const noexcept ->
+            typename traits::counter_type requires inspectable_ref_counted<RC>
+
+    {
+        return traits::reference_count(*mPtr);
+    }
+
+    /// @brief Returns the bound object after unbinding this without
+    ///        decrementing the reference counter.
+    constexpr auto release() noexcept -> RC *
+    {
+        return std::exchange(mPtr, nullptr);
+    }
+    /// @brief Replaces the managed object and binds the new
+    /// @param toBeBound will be pointed to and its reference count increased
+    constexpr void reset(RC *toBeBound) noexcept
+    {
+        *this = acquire(toBeBound);
+    }
+
+    friend inline auto operator==(intrusive_ptr const &,
+                                  intrusive_ptr const &) noexcept -> bool
+            = default;
+    friend inline auto operator<=>(intrusive_ptr const &,
+                                   intrusive_ptr const &) noexcept
+            -> std::strong_ordering = default;
+};
+
+template <>
+class intrusive_ptr<void, void> final
+{
+    detail::ref_ops_vtable const *mVTable;
+    void *mPtr;
+
+public:
+    ~intrusive_ptr() noexcept
+    {
+        if (mPtr != nullptr)
+        {
+            mVTable->release(mPtr);
+        }
+    }
+    intrusive_ptr() noexcept
+        : mVTable{nullptr}
+        , mPtr{nullptr}
+    {
+    }
+
+    intrusive_ptr(intrusive_ptr const &other) noexcept
+        : mVTable{other.mVTable}
+        , mPtr{other.mPtr}
+    {
+        if (mPtr != nullptr)
+        {
+            mVTable->add_reference(mPtr);
+        }
+    }
+
+    auto operator=(intrusive_ptr const &other) noexcept -> intrusive_ptr &
+    {
+        if (mPtr != nullptr)
+        {
+            mVTable->release(mPtr);
+        }
+        mVTable = other.mVTable;
+        mPtr = other.mPtr;
+        if (mPtr)
+        {
+            mVTable->add_reference(mPtr);
+        }
+
+        return *this;
+    }
+
+    intrusive_ptr(intrusive_ptr &&other) noexcept
+        : mVTable{std::exchange(other.mVTable, nullptr)}
+        , mPtr{std::exchange(other.mPtr, nullptr)}
+    {
+    }
+    auto operator=(intrusive_ptr &&other) noexcept -> intrusive_ptr &
+    {
+        if (mPtr != nullptr)
+        {
+            mVTable->release(mPtr);
+        }
+        mVTable = std::exchange(other.mVTable, nullptr);
+        mPtr = std::exchange(other.mPtr, nullptr);
+
+        return *this;
+    }
+
+    friend inline void swap(intrusive_ptr &lhs, intrusive_ptr &rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.mVTable, rhs.mVTable);
+        swap(lhs.mPtr, rhs.mPtr);
+    }
+
+private:
+    explicit intrusive_ptr(detail::ref_ops_vtable const *vTable, void *handle)
+        : mVTable{vTable}
+        , mPtr{handle}
+    {
+    }
+
+public:
+    template <ref_counted U>
+    static auto import(U *toBeBound) noexcept -> intrusive_ptr
+    {
+        if (toBeBound == nullptr)
+        {
+            return intrusive_ptr();
+        }
+        return intrusive_ptr(&detail::ref_ops_vtable_of<U>, toBeBound);
+    }
+    template <ref_counted U>
+    static auto acquire(U *toBeBound) noexcept -> intrusive_ptr
+    {
+        if (toBeBound == nullptr)
+        {
+            return intrusive_ptr();
+        }
+        reference_counted_traits<U>::add_reference(*toBeBound);
+        return intrusive_ptr(&detail::ref_ops_vtable_of<U>, toBeBound);
+    }
+
+    intrusive_ptr(std::nullptr_t) noexcept
+        : intrusive_ptr{}
+    {
+    }
+
+    template <ref_counted U>
+    intrusive_ptr(intrusive_ptr<U> const &other) noexcept
+        : mVTable(other ? &detail::ref_ops_vtable_of<U> : nullptr)
+        , mPtr(other.get())
+    {
+        if (other)
+        {
+            reference_counted_traits<U>::add_reference(*other);
+        }
+    }
+    template <ref_counted U>
+    intrusive_ptr(intrusive_ptr<U> &&other) noexcept
+        : mVTable(other ? &detail::ref_ops_vtable_of<U> : nullptr)
+        , mPtr(other.release())
+    {
+    }
+
+    using element_type = void;
+    using handle_type = intrusive_ptr;
+
+    /// @brief Returns true if an object is bound false otherwise
+    explicit operator bool() const noexcept
+    {
+        return mPtr != nullptr;
+    }
+
+    /// @brief Returns a pointer to the bound object or nullptr if empty.
+    auto get() const noexcept -> void *
+    {
+        return mPtr;
+    }
+    auto get_handle() const noexcept -> intrusive_ptr<void>
+    {
+        return *this;
+    }
+    template <ref_counted U>
+    auto release_as() noexcept -> U *
+    {
+        mVTable = nullptr;
+        return static_cast<U *>(std::exchange(mPtr, nullptr));
+    }
+
+    friend inline auto operator==(intrusive_ptr const &lhs,
+                                  intrusive_ptr const &rhs) noexcept -> bool
+    {
+        return lhs.mPtr == rhs.mPtr;
+    }
+    friend inline auto operator<=>(intrusive_ptr const &lhs,
+                                   intrusive_ptr const &rhs) noexcept
+            -> std::strong_ordering
+    {
+        return lhs.mPtr <=> rhs.mPtr;
+    }
+};
+
+template <typename T, typename RC>
+    requires std::same_as<RC, void> || ref_counted<RC>
+class intrusive_ptr
+{
+    T *mPtr;
+    intrusive_ptr<RC> mHandle;
+
+public:
+    constexpr intrusive_ptr() noexcept
+        : mPtr{}
+        , mHandle{}
+    {
+    }
+
+    constexpr intrusive_ptr(intrusive_ptr const &) noexcept = default;
+    constexpr auto operator=(intrusive_ptr const &) noexcept
+            -> intrusive_ptr & = default;
+
+    constexpr intrusive_ptr(intrusive_ptr &&other) noexcept
+        : mPtr{std::exchange(other.mPtr, nullptr)}
+        , mHandle{static_cast<intrusive_ptr<RC> &&>(other.mHandle)}
+    {
+    }
+    constexpr auto operator=(intrusive_ptr &&other) noexcept -> intrusive_ptr &
+    {
+        mPtr = std::exchange(other.mPtr, nullptr);
+        mHandle = static_cast<intrusive_ptr<RC> &&>(other.mHandle);
+        return *this;
+    }
+
+    friend inline void swap(intrusive_ptr &lhs, intrusive_ptr &rhs) noexcept
+    {
+        using std::swap;
+        swap(lhs.mPtr, rhs.mPtr);
+        swap(lhs.mHandle, rhs.mHandle);
+    }
+
+    constexpr intrusive_ptr(std::nullptr_t) noexcept
+        : intrusive_ptr{}
+    {
+    }
+
+    constexpr intrusive_ptr(intrusive_ptr<RC> const &handle, T *ptr) noexcept
+        : mPtr{handle ? ptr : nullptr}
+        , mHandle{handle}
+    {
+    }
+    template <ref_counted U>
+        requires std::constructible_from<intrusive_ptr<RC>, intrusive_ptr<U>>
+    constexpr intrusive_ptr(intrusive_ptr<U> const &handle, T *ptr) noexcept
+        : mPtr{handle ? ptr : nullptr}
+        , mHandle{handle}
+    {
+    }
+    constexpr intrusive_ptr(intrusive_ptr<RC> &&handle, T *ptr) noexcept
+        : mPtr{handle ? ptr : nullptr}
+        , mHandle{static_cast<intrusive_ptr<RC> &&>(handle)}
+    {
+    }
+    template <ref_counted U>
+        requires std::constructible_from<intrusive_ptr<RC>, intrusive_ptr<U>>
+    constexpr intrusive_ptr(intrusive_ptr<U> &&handle, T *ptr) noexcept
+        : mPtr{handle ? ptr : nullptr}
+        , mHandle{static_cast<intrusive_ptr<RC> &&>(handle)}
+    {
+    }
+
+    using element_type = T;
+    using handle_type = intrusive_ptr<RC>;
+
+    explicit operator bool() const noexcept
+    {
+        return mHandle.operator bool();
+    }
+
+    constexpr auto operator*() const noexcept -> T &
+    {
+        return *mPtr;
+    }
+    constexpr auto operator->() const noexcept -> T *
+    {
+        return mPtr;
+    }
+
+    constexpr auto get() const noexcept -> T *
+    {
+        return mPtr;
+    }
+    constexpr auto get_handle() const noexcept -> intrusive_ptr<RC>
+    {
+        return mHandle;
+    }
+
+    /// @brief If T satisfies inspectable_ref_counted it returns the
+    ///        (approximate) number of references. Only the value 1 is
+    ///        guaranteed to be stable even in multi-threaded environments. This
+    ///        API behaves the same as @ref reference_count and exists for
+    ///        std::shared_ptr compatibility.
+    constexpr auto use_count() const noexcept ->
+            typename reference_counted_traits<RC>::counter_type requires
+            inspectable_ref_counted<RC>
+
+    {
+        return mHandle.use_count();
+    }
+    /// @brief If T satisfies inspectable_ref_counted it returns the
+    ///        (approximate) number of references. Only the value 1 is
+    ///        guaranteed to be stable even in multi-threaded environments.
+    constexpr auto reference_count() const noexcept ->
+            typename reference_counted_traits<RC>::counter_type requires
+            inspectable_ref_counted<RC>
+
+    {
+        return mHandle.reference_count();
+    }
+};
+
+template <typename T, typename U>
+    requires std::same_as<U, void> || ref_counted<U>
+inline auto static_pointer_cast(intrusive_ptr<U> const &ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::acquire(static_cast<T *>(ptr.get()));
+}
+template <typename T, ref_counted U>
+inline auto static_pointer_cast(intrusive_ptr<U> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(static_cast<T *>(ptr.release()));
+}
+template <typename T>
+inline auto static_pointer_cast(intrusive_ptr<void> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(ptr.template release_as<T>());
+}
+
+template <ref_counted T, ref_counted U>
+inline auto dynamic_pointer_cast(intrusive_ptr<U> const &ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::acquire(dynamic_cast<T *>(ptr.get()));
+}
+template <ref_counted T, ref_counted U>
+inline auto dynamic_pointer_cast(intrusive_ptr<U> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(dynamic_cast<T *>(ptr.release()));
+}
+
+template <ref_counted T, ref_counted U>
+inline auto const_pointer_cast(intrusive_ptr<U> const &ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::acquire(const_cast<T *>(ptr.get()));
+}
+template <ref_counted T, ref_counted U>
+inline auto const_pointer_cast(intrusive_ptr<U> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(const_cast<T *>(ptr.release()));
+}
+
+template <typename T, typename U>
+    requires std::same_as<U, void> || ref_counted<U>
+inline auto reinterpret_pointer_cast(intrusive_ptr<U> const &ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::acquire(reinterpret_cast<T *>(ptr.get()));
+}
+template <typename T, ref_counted U>
+inline auto reinterpret_pointer_cast(intrusive_ptr<U> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(reinterpret_cast<T *>(ptr.release()));
+}
+template <typename T>
+inline auto reinterpret_pointer_cast(intrusive_ptr<void> &&ptr) noexcept
+        -> intrusive_ptr<T>
+{
+    return intrusive_ptr<T>::import(ptr.template release_as<T>());
+}
+
+} // namespace dplx::cncr

--- a/src/dplx/cncr/intrusive_ptr.test.cpp
+++ b/src/dplx/cncr/intrusive_ptr.test.cpp
@@ -1,0 +1,439 @@
+
+// Copyright Henrik Steffen Gaßmann 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/cncr/intrusive_ptr.hpp"
+
+#include <catch2/catch.hpp>
+#include <dplx/cncr/workaround.h>
+#include <dplx/predef/compiler.h>
+
+#include "cncr_tests/test_utils.hpp"
+
+namespace cncr_tests
+{
+
+class alien_ref_counted
+{
+    int mCounter{1};
+
+public:
+    void AddReference()
+    {
+        mCounter += 1;
+    }
+    void Release()
+    {
+        mCounter -= 1;
+    }
+};
+
+} // namespace cncr_tests
+
+template <>
+struct dplx::cncr::reference_counted_traits<cncr_tests::alien_ref_counted>
+{
+    using counter_type = void;
+    using ref_counted = cncr_tests::alien_ref_counted;
+
+    static void add_reference(ref_counted &v) noexcept
+    {
+        v.AddReference();
+    }
+
+    static void release(ref_counted &v) noexcept
+    {
+        v.Release();
+    }
+};
+#if DPLX_CNCR_WORKAROUND_TESTED_AT(DPLX_COMP_CLANG, 13, 0, 1)
+// clang doesn't support disabling member functions with requires during
+// explicit instantiation
+#else
+template class dplx::cncr::intrusive_ptr<cncr_tests::alien_ref_counted>;
+#endif
+static_assert(dplx::cncr::ref_counted<cncr_tests::alien_ref_counted>);
+static_assert(
+        !dplx::cncr::inspectable_ref_counted<cncr_tests::alien_ref_counted>);
+
+namespace cncr_tests
+{
+class test_ref_counted
+{
+    mutable int mCounter{1};
+
+public:
+    constexpr void add_reference() const noexcept
+    {
+        mCounter += 1;
+    }
+    constexpr void release() const noexcept
+    {
+        mCounter -= 1;
+    }
+    constexpr auto reference_count() const noexcept -> int
+    {
+        return mCounter;
+    }
+};
+static_assert(cncr::detail::dplx_ref_counted<test_ref_counted>);
+static_assert(cncr::ref_counted<test_ref_counted>);
+
+using test_intrusive_ptr = cncr::intrusive_ptr<test_ref_counted>;
+
+TEST_CASE("intrusive_ptr should be default constructible and empty")
+{
+    test_intrusive_ptr ptr1;
+    CHECK(!ptr1);
+
+    test_intrusive_ptr ptr2{};
+    CHECK(!ptr2);
+}
+
+TEST_CASE("intrusive_ptr can be initialized by a nullptr literal")
+{
+    test_intrusive_ptr ptr1(nullptr);
+    CHECK(!ptr1);
+
+    test_intrusive_ptr ptr2{nullptr};
+    CHECK(!ptr2);
+
+    test_intrusive_ptr ptr3 = nullptr;
+    CHECK(!ptr3);
+}
+
+TEST_CASE("intrusive_ptr_acquire should create a intrusive_ptr and increase "
+          "its reference count")
+{
+    test_ref_counted counted;
+
+    auto subject = cncr::intrusive_ptr_acquire(&counted);
+
+    CHECK(subject.get() == &counted);
+    CHECK(counted.reference_count() == 2);
+}
+TEST_CASE("intrusive_ptr_acquire should create a intrusive_ptr from nullptr")
+{
+    test_ref_counted *null = nullptr;
+    auto subject = cncr::intrusive_ptr_acquire(null);
+
+    CHECK(!subject);
+    CHECK(subject.get() == nullptr);
+}
+
+TEST_CASE("intrusive_ptr should call release() on the wrapped object on "
+          "destruction")
+{
+    test_ref_counted counted;
+    {
+        auto subject = cncr::intrusive_ptr_import(&counted);
+
+        CHECK(counted.reference_count() == 1);
+    }
+    CHECK(counted.reference_count() == 0);
+}
+
+TEST_CASE("intrusive_ptr_import should create a intrusive_ptr without "
+          "increasing its reference count")
+{
+    test_ref_counted counted;
+    auto subject = cncr::intrusive_ptr_import(&counted);
+
+    CHECK(subject.get() == &counted);
+    CHECK(counted.reference_count() == 1);
+}
+TEST_CASE("intrusive_ptr_import should create a intrusive_ptr from nullptr")
+{
+    test_ref_counted *null = nullptr;
+    auto subject = cncr::intrusive_ptr_import(null);
+
+    CHECK(!subject);
+    CHECK(subject.get() == nullptr);
+}
+
+TEST_CASE("intrusive_ptr instance")
+{
+    test_ref_counted counted;
+    auto subject = cncr::intrusive_ptr_import(&counted);
+    REQUIRE(subject.get() == &counted);
+    REQUIRE(counted.reference_count() == 1);
+
+    SECTION("nullptr can be assigned to an instance")
+    {
+        subject = nullptr;
+
+        CHECK(subject.get() == nullptr);
+    }
+
+    SECTION("should be copy constructible and add a new reference")
+    {
+        test_intrusive_ptr copy = subject;
+
+        CHECK(subject.get() == &counted);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 2);
+    }
+
+    SECTION("should be copy assignable and add a new reference")
+    {
+        test_intrusive_ptr copy;
+        auto &&assignmentResult = (copy = subject);
+
+        CHECK(&assignmentResult == &copy);
+        CHECK(subject.get() == &counted);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 2);
+    }
+
+    SECTION("should be move constructible avoiding a reference increment")
+    {
+        test_intrusive_ptr copy = std::move(subject);
+
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should be move assignable avoiding a reference increment")
+    {
+        test_intrusive_ptr copy;
+        auto &&assignmentResult = (copy = std::move(subject));
+
+        CHECK(&assignmentResult == &copy);
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should be swappable avoiding a reference increment")
+    {
+        test_intrusive_ptr copy;
+        swap(subject, copy);
+
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("reference_count() should return the reference count")
+    {
+        CHECK(subject.reference_count() == 1);
+        counted.add_reference();
+        CHECK(subject.reference_count() == 2);
+    }
+    SECTION("use_count() should return the reference count")
+    {
+        CHECK(subject.use_count() == 1);
+        counted.add_reference();
+        CHECK(subject.use_count() == 2);
+    }
+
+    SECTION("should provide an overloaded dereference operator")
+    {
+        CHECK(&(*subject) == &counted);
+    }
+    SECTION("should provide an overloaded member access operator")
+    {
+        CHECK(subject.operator->() == &counted);
+    }
+
+    SECTION("should provide a method to release ownership")
+    {
+        CHECK(subject.release() == &counted);
+        CHECK(!subject);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should be convertible to intrusive_ptr<void>")
+    {
+        cncr::intrusive_ptr<void> copy = subject;
+
+        CHECK(subject.get() == &counted);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 2);
+    }
+    SECTION("should be movable to intrusive_ptr<void>")
+    {
+        cncr::intrusive_ptr<void> copy = std::move(subject);
+
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+}
+
+TEST_CASE("intrusive_ptr<void> should be default constructible and empty")
+{
+    cncr::intrusive_ptr<void> ptr1;
+    CHECK(!ptr1);
+
+    cncr::intrusive_ptr<void> ptr2{};
+    CHECK(!ptr2);
+}
+
+TEST_CASE("intrusive_ptr<void> can be initialized by a nullptr literal")
+{
+    cncr::intrusive_ptr<void> ptr1(nullptr);
+    CHECK(!ptr1);
+
+    cncr::intrusive_ptr<void> ptr2{nullptr};
+    CHECK(!ptr2);
+
+    cncr::intrusive_ptr<void> ptr3 = nullptr;
+    CHECK(!ptr3);
+}
+TEST_CASE("intrusive_ptr<void> can be initialized by an empty intrusive_ptr")
+{
+    test_intrusive_ptr input;
+
+    cncr::intrusive_ptr<void> copied = input;
+    CHECK(!copied);
+    CHECK(copied.get() == nullptr);
+
+    cncr::intrusive_ptr<void> moved = std::move(input);
+    CHECK(!moved);
+    CHECK(moved.get() == nullptr);
+}
+
+TEST_CASE("intrusive_ptr<void>::acquire should create a intrusive_ptr and "
+          "increase its reference count")
+{
+    test_ref_counted counted;
+
+    auto subject = cncr::intrusive_ptr<void>::acquire(&counted);
+
+    CHECK(subject.get() == &counted);
+    CHECK(counted.reference_count() == 2);
+}
+TEST_CASE("intrusive_ptr<void>::acquire should create a intrusive_ptr from "
+          "nullptr")
+{
+    test_ref_counted *null = nullptr;
+    auto subject = cncr::intrusive_ptr<void>::acquire(null);
+
+    CHECK(!subject);
+    CHECK(subject.get() == nullptr);
+}
+
+TEST_CASE("intrusive_ptr<void> should call release() on the wrapped object on "
+          "destruction")
+{
+    test_ref_counted counted;
+    {
+        auto subject = cncr::intrusive_ptr<void>::import(&counted);
+
+        CHECK(counted.reference_count() == 1);
+    }
+    CHECK(counted.reference_count() == 0);
+}
+
+TEST_CASE("intrusive_ptr<void>::import should create a intrusive_ptr without "
+          "increasing its reference count")
+{
+    test_ref_counted counted;
+    auto subject = cncr::intrusive_ptr<void>::import(&counted);
+
+    CHECK(subject.get() == &counted);
+    CHECK(counted.reference_count() == 1);
+}
+TEST_CASE("intrusive_ptr<void>::import should create a intrusive_ptr from "
+          "nullptr")
+{
+    test_ref_counted *null = nullptr;
+    auto subject = cncr::intrusive_ptr<void>::import(null);
+
+    CHECK(!subject);
+    CHECK(subject.get() == nullptr);
+}
+
+TEST_CASE("intrusive_ptr<void> instance")
+{
+    test_ref_counted counted;
+    auto subject = cncr::intrusive_ptr<void>::import(&counted);
+    REQUIRE(subject.get() == &counted);
+    REQUIRE(counted.reference_count() == 1);
+
+    SECTION("nullptr can be assigned to an instance")
+    {
+        subject = nullptr;
+
+        CHECK(subject.get() == nullptr);
+    }
+
+    SECTION("should be copy constructible and add a new reference")
+    {
+        cncr::intrusive_ptr<void> copy = subject;
+
+        CHECK(subject.get() == &counted);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 2);
+    }
+
+    SECTION("should be copy assignable and add a new reference")
+    {
+        cncr::intrusive_ptr<void> copy;
+        auto &&assignmentResult = (copy = subject);
+
+        CHECK(&assignmentResult == &copy);
+        CHECK(subject.get() == &counted);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 2);
+    }
+
+    SECTION("should be move constructible avoiding a reference increment")
+    {
+        cncr::intrusive_ptr<void> copy = std::move(subject);
+
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should be move assignable avoiding a reference increment")
+    {
+        cncr::intrusive_ptr<void> copy;
+        auto &&assignmentResult = (copy = std::move(subject));
+
+        CHECK(&assignmentResult == &copy);
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should be swappable avoiding a reference increment")
+    {
+        cncr::intrusive_ptr<void> copy;
+        swap(subject, copy);
+
+        CHECK(subject.get() == nullptr);
+        CHECK(copy.get() == &counted);
+        CHECK(counted.reference_count() == 1);
+    }
+
+    SECTION("should provide a method to release ownership")
+    {
+        CHECK(subject.release_as<test_ref_counted>() == &counted);
+        CHECK(!subject);
+        CHECK(counted.reference_count() == 1);
+    }
+}
+
+TEST_CASE("aliasing ref ptr type deduction")
+{
+    int x = 3;
+    test_ref_counted counted;
+
+    auto orig = cncr::intrusive_ptr_import(&counted);
+    auto synth = cncr::intrusive_ptr(orig, &x);
+
+    CHECK(synth);
+    CHECK(synth.get() == &x);
+    CHECK(synth.get_handle() == orig);
+}
+
+} // namespace cncr_tests
+
+template class dplx::cncr::intrusive_ptr<cncr_tests::test_ref_counted>;


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

<!-- ### Purpose -->
<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
You may remove this if you're fixing a typo.
-->
Implement a smart pointer for reference counted objects. 
Support aliasing the reference counted object with an unrelated object.
Support adapting foreign reference counting APIs.

Add a customization point for reference counted types which can be used
to adapt foreign reference counting APIs.

### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
Add a `template<typename T, ref_counted RC> class intrusive_ptr` which
is specialized for the `T == RC` case to act like the usual intrusive pointer
and otherwise like an aliasing pointer. `template<> class intrusive_pointer<void, void>`
is a type erased handle.

<!-- ### Additional explanatory comments -->

***

### Checklist
- [ ] Tested on `x64-linux-clang-debug`
- [ ] Tested on `x64-linux-gcc-debug`
- [x] Tested on `x64-windows-clang-debug`
- [x] Tested on `x64-windows-msvc-debug`
- [x] Tested on `x64-windows-msvc-lto`
- [x] `clang-format` is happy

Resolves #1
