### PR TITLE
Prevent tag_invoke name collisions within the cncr namespace

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -138,6 +138,7 @@
                             ".git",
                             ".vs",
                             ".vscode",
+                            "build",
                             "out",
                             "vcpkg_installed"
                         ]

--- a/src/cncr_tests/test_utils.hpp
+++ b/src/cncr_tests/test_utils.hpp
@@ -7,6 +7,12 @@
 
 #pragma once
 
+#include <dplx/predef/compiler.h>
+
+#ifdef DPLX_COMP_GNUC_AVAILABLE
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+
 namespace dplx
 {
 }

--- a/src/dplx/cncr/tag_invoke.hpp
+++ b/src/dplx/cncr/tag_invoke.hpp
@@ -44,23 +44,23 @@ using tag_t = std::decay_t<decltype(Tag)>;
 
 inline namespace cpo
 {
-inline constexpr detail::cpo::tag_invoke_fn tag_invoke{};
+inline constexpr dplx::detail::cpo::tag_invoke_fn tag_invoke{};
 }
 
 template <typename Tag, typename... TArgs>
 concept tag_invocable
-        = std::invocable<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
+        = std::invocable<dplx::detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 concept nothrow_tag_invocable = tag_invocable<Tag, TArgs...> && std::
-        is_nothrow_invocable_v<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
+        is_nothrow_invocable_v<dplx::detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 using tag_invoke_result
-        = std::invoke_result<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
+        = std::invoke_result<dplx::detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 using tag_invoke_result_t
-        = std::invoke_result_t<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
+        = std::invoke_result_t<dplx::detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 } // namespace dplx::cncr

--- a/src/dplx/cncr/tag_invoke.hpp
+++ b/src/dplx/cncr/tag_invoke.hpp
@@ -8,10 +8,9 @@
 #pragma once
 
 #include <concepts>
-
 #include <type_traits>
 
-namespace dplx::detail::cpo_impl
+namespace dplx::detail::cpo
 {
 
 struct tag_invoke_fn
@@ -35,7 +34,7 @@ struct tag_invoke_fn
 
 void tag_invoke() = delete;
 
-} // namespace dplx::detail::cpo_impl
+} // namespace dplx::detail::cpo
 
 namespace dplx::cncr
 {
@@ -43,22 +42,25 @@ namespace dplx::cncr
 template <auto &Tag>
 using tag_t = std::decay_t<decltype(Tag)>;
 
-inline constexpr detail::cpo_impl::tag_invoke_fn tag_invoke{};
+inline namespace cpo
+{
+inline constexpr detail::cpo::tag_invoke_fn tag_invoke{};
+}
 
 template <typename Tag, typename... TArgs>
 concept tag_invocable
-        = std::invocable<detail::cpo_impl::tag_invoke_fn, Tag, TArgs...>;
+        = std::invocable<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 concept nothrow_tag_invocable = tag_invocable<Tag, TArgs...> && std::
-        is_nothrow_invocable_v<detail::cpo_impl::tag_invoke_fn, Tag, TArgs...>;
+        is_nothrow_invocable_v<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 using tag_invoke_result
-        = std::invoke_result<detail::cpo_impl::tag_invoke_fn, Tag, TArgs...>;
+        = std::invoke_result<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 template <typename Tag, typename... TArgs>
 using tag_invoke_result_t
-        = std::invoke_result_t<detail::cpo_impl::tag_invoke_fn, Tag, TArgs...>;
+        = std::invoke_result_t<detail::cpo::tag_invoke_fn, Tag, TArgs...>;
 
 } // namespace dplx::cncr


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
Moving the CPO to an inline namespace resolves the entity redifinition problem by not reserving the `tag_invoke` entity in the `cncr` namespace. However, `tag_invoke` specializations need to be inline friends within the `cncr` namespace, because otherwise the `tag_invoke` symbol becomes ambiguous.

### Additional explanatory comments

***

### Checklist
- [x] Tested on `x64-linux-clang-debug`
- [x] Tested on `x64-linux-gcc-debug`
- [x] Tested on `x64-windows-clang-debug`
- [x] Tested on `x64-windows-msvc-debug`
- [x] Tested on `x64-windows-msvc-lto`
- [x] `clang-format` is happy

Resolves #5 <!-- associate the motivating issue -->
