### PR TITLE
Fix aliasing intrusive_ptr API oversights

### DIFF
--- a/src/dplx/cncr/intrusive_ptr.hpp
+++ b/src/dplx/cncr/intrusive_ptr.hpp
@@ -523,27 +523,29 @@ public:
     }
 
     constexpr intrusive_ptr(intrusive_ptr<RC> const &handle, T *ptr) noexcept
-        : mPtr{handle ? ptr : nullptr}
-        , mHandle{handle}
+        : mPtr{handle && ptr ? ptr : nullptr}
+        , mHandle{handle && ptr ? handle : nullptr}
     {
     }
     template <ref_counted U>
         requires std::constructible_from<intrusive_ptr<RC>, intrusive_ptr<U>>
     constexpr intrusive_ptr(intrusive_ptr<U> const &handle, T *ptr) noexcept
-        : mPtr{handle ? ptr : nullptr}
-        , mHandle{handle}
+        : mPtr{handle && ptr ? ptr : nullptr}
+        , mHandle{handle && ptr ? handle : nullptr}
     {
     }
     constexpr intrusive_ptr(intrusive_ptr<RC> &&handle, T *ptr) noexcept
-        : mPtr{handle ? ptr : nullptr}
-        , mHandle{static_cast<intrusive_ptr<RC> &&>(handle)}
+        : mPtr{handle && ptr ? ptr : nullptr}
+        , mHandle{handle && ptr ? static_cast<intrusive_ptr<RC> &&>(handle)
+                                : intrusive_ptr<RC>{}}
     {
     }
     template <ref_counted U>
         requires std::constructible_from<intrusive_ptr<RC>, intrusive_ptr<U>>
     constexpr intrusive_ptr(intrusive_ptr<U> &&handle, T *ptr) noexcept
-        : mPtr{handle ? ptr : nullptr}
-        , mHandle{static_cast<intrusive_ptr<RC> &&>(handle)}
+        : mPtr{handle && ptr ? ptr : nullptr}
+        , mHandle{handle && ptr ? static_cast<intrusive_ptr<U> &&>(handle)
+                                : intrusive_ptr<U>{}}
     {
     }
 
@@ -552,7 +554,7 @@ public:
 
     explicit operator bool() const noexcept
     {
-        return mHandle.operator bool();
+        return mPtr != nullptr;
     }
 
     constexpr auto operator*() const noexcept -> T &
@@ -563,6 +565,10 @@ public:
     {
         return mPtr;
     }
+
+    friend constexpr auto operator==(intrusive_ptr const &,
+                                     intrusive_ptr const &) noexcept -> bool
+            = default;
 
     constexpr auto get() const noexcept -> T *
     {

--- a/src/dplx/cncr/intrusive_ptr.test.cpp
+++ b/src/dplx/cncr/intrusive_ptr.test.cpp
@@ -444,3 +444,4 @@ TEST_CASE("aliasing ref ptr type deduction")
 } // namespace cncr_tests
 
 template class dplx::cncr::intrusive_ptr<cncr_tests::test_ref_counted>;
+template class dplx::cncr::intrusive_ptr<int, cncr_tests::test_ref_counted>;


### PR DESCRIPTION
- Ensure (ptr == nullptr) <=> (handle == nullptr)
- Add equality comparison operator

<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->

Resolves #10 

### Solution Sketch
See associated issue.


