### PR TITLE
Return references from `intrusive_ptr::get_handle()`

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           vcpkgDirectory: ${{ github.workspace }}/build/vcpkg
           vcpkgGitCommitId: 8b62d95a81afcb9efe74bebeb62f04c1e0e2a003
-          appendedCacheKey: r01
+          appendedCacheKey: r02
 
       - if: matrix.os == 'windows-2022'
         name: Add MSVC to PATH


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->

Resolves #13 <!-- associate the motivating issue -->


### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
Returning by values from `get_handle()` would trash the reference handle ref counter unnecessarily in case of simple property access. This comes at the cost of returning a reference to internal state. Optimize `get_handle()` for rvalue access in which case we can move the handle out of this.


### Additional explanatory comments

Also add missing pointer cast overloads for aliasing intrusive pointers.
