### PR TITLE
Implement a status domain generator for enums

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,6 +91,12 @@ IncludeCategories:
   - Regex:           '^<boost/'
     Priority:        5
     CaseSensitive:   false
+  - Regex:           '^<dplx/cncr[/\.].*'
+    Priority:        29
+    CaseSensitive:   true
+  - Regex:           '^<dplx/.*'
+    Priority:        27
+    CaseSensitive:   true
   - Regex:           '^<.*'
     Priority:        20
     CaseSensitive:   false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,15 +5,20 @@ Checks: >
   clang-analyzer-*,
   clang-diagnostic-*,
   cppcoreguidelines-*,
+    -cppcoreguidelines-avoid-c-arrays,
     -cppcoreguidelines-special-member-functions,
   modernize-*,
+    -modernize-avoid-c-arrays,
+    -modernize-use-default-member-init,
   performance-*,
   portability-*,
   readability-*,
     -readability-identifier-length,
-    -readability-named-parameter
+    -readability-named-parameter,
+    -readability-redundant-member-init,
+    -readability-static-accessed-through-instance
 WarningsAsErrors: true
-HeaderFilterRegex: ""
+HeaderFilterRegex: ".*/src/dplx/.*"
 FormatStyle: file
 CheckOptions:
   - key: modernize-use-override.AllowOverrideAndFinal

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -38,8 +38,8 @@ jobs:
         uses: lukka/run-vcpkg@v10
         with:
           vcpkgDirectory: ${{ github.workspace }}/build/vcpkg
-          vcpkgGitCommitId: 8b62d95a81afcb9efe74bebeb62f04c1e0e2a003
-          appendedCacheKey: r02
+          vcpkgGitCommitId: 6ca56aeb457f033d344a7106cb3f9f1abf8f4e98
+          #appendedCacheKey: r00
 
       - if: matrix.os == 'windows-2022'
         name: Add MSVC to PATH

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -24,6 +24,7 @@ add_custom_command(
     DEPENDS
         "${CMAKE_CURRENT_LIST_DIR}/index.rst"
         "${CMAKE_CURRENT_LIST_DIR}/modules/concepts.rst"
+        "${CMAKE_CURRENT_LIST_DIR}/modules/data_defined_status_domain.rst"
         "${CMAKE_CURRENT_LIST_DIR}/modules/math_supplement.rst"
         "${CMAKE_CURRENT_LIST_DIR}/modules/misc.rst"
         "${CMAKE_CURRENT_LIST_DIR}/modules/overloaded.rst"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
    :caption: Contents:
 
    modules/concepts.rst
+   modules/data_defined_status_domain.rst
    modules/intrusive_ptr.rst
    modules/math_supplement.rst
    modules/misc.rst

--- a/docs/modules/data_defined_status_domain.rst
+++ b/docs/modules/data_defined_status_domain.rst
@@ -1,0 +1,125 @@
+
+============================
+ Data defined Status Domain
+============================
+
+::
+
+    #include <dplx/cncr/data_defined_status_domain.hpp>
+    namespace dplx::cncr {}
+
+.. namespace:: dplx::cncr
+
+This module allows "generating" a ``status_code_domain`` (see the 
+`status-code <https://github.com/ned14/status-code>`_ GitHub project) for a
+return code enumeration. In order to generate a ``status_code_domain`` one
+needs to specialize :texpr:`status_enum_definition` with the enumeration type,
+like so:
+::
+
+    enum class test_errc
+    {
+        success = 0,
+        perm = 3,
+        other_success = 5,
+        not_implemented = 7,
+    };
+
+    template <>
+    struct dplx::cncr::status_enum_definition<test_errc>
+        : status_enum_definition_defaults<test_errc>
+    {
+        static constexpr char domain_id[]
+                = "{09E0ECBF-A737-454D-8633-17E733CDE15F}";
+        static constexpr char domain_name[] = "test-domain";
+
+        static constexpr value_descriptor values[] = {
+                {        code::success,           generic_errc::success,       "yay!"},
+                {           code::perm, generic_errc::permission_denied,      "oh no"},
+                {  code::other_success,           generic_errc::success,     "oh kay"},
+                {code::not_implemented,           generic_errc::unknown, "till later"},
+        };
+    }
+
+.. concept:: template <typename Enum> \
+             status_enum
+
+    **Notation**
+    
+    .. type:: definition = status_enum_definition<Enum>
+
+        The specialization containing the domain name, id and value
+        descriptions.
+
+    **Valid Expressions**
+
+    - :expr:`std::string_view{definition::domain_name}`, the domain name
+      specified can be constexpr converted to a :texpr:`string_view`.
+    - :expr:`std::string_view{definition::domain_id}`, the domain uuid
+      specified can be constexpr converted to a :texpr:`string_view`.
+    - :expr:`std::span<status_enum_value_descriptor<Enum> const>{definition::values}`
+      the
+
+.. struct:: template <typename Enum> \
+            status_enum_value_descriptor
+
+    A data first descriptor tuple which consists of a description and an
+    equivalent code for a :texpr:`value`.
+
+    .. member:: Enum value
+
+        The value to be described.
+
+    .. member:: ::system_error2::errc equivalent
+
+        The generic code equivalent to :texpr:`value`. 
+        
+        The ``::system_error2::errc::success`` and
+        ``::system_error2::errc::unknown`` values  indicate that :texpr:`value`
+        is not an error or no equivalent generic code exists respectively.
+
+    .. member:: std::string_view description
+
+        A string describing the situation indicated by :texpr:`value`.
+
+.. struct:: template <typename Enum> \
+            status_enum_definition_defaults
+
+    A CRTP base class for :texpr:`status_enum_definition` specializiations which
+    introduces a few type aliases allowing for terser definitions.
+
+    .. type:: code = Enum
+
+        The enumeration type the status code is generated for.
+
+    .. type:: generic_errc = ::system_error2::errc
+
+        The generic error enumeration from the status-code library.
+
+    .. type:: value_descriptor = status_enum_value_descriptor<Enum>
+
+        The value descriptor type for :texpr:`Enum`.
+
+.. var:: template <status_enum Enum> \
+         inline constexpr \
+         data_defined_status_domain_type<Enum> data_defined_status_domain
+
+    The default status domain instance for data defined status enumerations.
+    There shouldn't be any need to reference it directly.
+
+.. class:: template <status_enum Enum> \
+           data_defined_status_domain_type \
+           : public SYSTEM_ERROR2_NAMESPACE::status_code_domain
+
+    The domain type template which implements a status domain based on the
+    :expr:`status_enum_definition<Enum>`.
+
+    .. seealso::
+
+        The  `base class documentation <https://ned14.github.io/status-code/doc_status_code_domain.html#standardese-system_error2__status_code_domain>`_.
+
+.. struct:: template <status_enum Enum> \
+            status_enum_definition
+
+    This template serves as the main customization point. There exists no main
+    definition. See the example given at the top for a specialization example.

--- a/sources.cmake
+++ b/sources.cmake
@@ -5,6 +5,7 @@ dplx_target_sources(concrete
 
     PUBLIC
         cncr/concepts
+        cncr/data_defined_status_domain
         cncr/intrusive_ptr
         cncr/math_supplement
         cncr/misc

--- a/src/dplx/cncr/data_defined_status_domain.hpp
+++ b/src/dplx/cncr/data_defined_status_domain.hpp
@@ -1,0 +1,379 @@
+
+// Copyright Henrik Steffen Gaßmann 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <concepts>
+#include <initializer_list>
+#include <span>
+#include <string_view>
+
+#include <status-code/generic_code.hpp>
+#include <status-code/status_code.hpp>
+#include <status-code/status_code_domain.hpp>
+
+#include <dplx/predef/compiler.h>
+
+#include <dplx/cncr/workaround.h>
+
+#if DPLX_CNCR_WORKAROUND_TESTED_AT(DPLX_COMP_CLANG, 14, 0, 6)
+#define DPLX_CNCR_STATUS_CONSTEXPR inline
+#else
+#define DPLX_CNCR_STATUS_CONSTEXPR constexpr
+#endif
+
+namespace dplx::cncr
+{
+
+namespace system_error = SYSTEM_ERROR2_NAMESPACE;
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+
+template <typename Enum>
+struct status_enum_value_descriptor
+{
+    Enum value;
+    system_error::errc equivalent;
+    std::string_view description;
+};
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
+
+template <typename Enum>
+struct status_enum_definition_defaults
+{
+    using code = Enum;
+    using generic_errc = system_error::errc;
+
+    using value_descriptor = status_enum_value_descriptor<code>;
+};
+
+template <typename Enum>
+    requires std::default_initializable<Enum> && std::movable<
+            Enum> && std::equality_comparable<Enum>
+struct status_enum_definition;
+
+// clang-format off
+template <typename T>
+concept status_enum
+        = !system_error::is_status_code<T>::value
+        && std::constructible_from<
+                std::span<status_enum_value_descriptor<T> const>,
+                decltype(status_enum_definition<T>::values)>
+        && !std::span<status_enum_value_descriptor<T> const>(
+                status_enum_definition<T>::values)
+                .empty()
+        && requires {
+            { status_enum_definition<T>::domain_name }
+                -> std::convertible_to<std::string_view>;
+            { status_enum_definition<T>::domain_id }
+                -> std::convertible_to<std::string_view>;
+        };
+// clang-format on
+
+template <status_enum Enum>
+consteval auto validate_status_enum_definition_data() noexcept -> bool
+{
+    using definition = status_enum_definition<Enum>;
+    using value_descriptor = status_enum_value_descriptor<Enum>;
+
+    value_descriptor const *const begin = std::begin(definition::values);
+    value_descriptor const *const end = std::end(definition::values);
+    // is not empty
+    if (begin == end)
+    {
+        return false;
+    }
+
+    // is sorted
+    for (value_descriptor const *it = begin, *next = begin + 1; next != end;
+         it = next++)
+    {
+        if (it->value > next->value)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// NOLINTBEGIN(cppcoreguidelines-virtual-class-destructor)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-static-cast-downcast)
+
+template <status_enum Enum>
+class data_defined_status_domain_type;
+
+template <status_enum Enum>
+using data_defined_status_code
+        = system_error::status_code<data_defined_status_domain_type<Enum>>;
+
+#if defined(DPLX_COMP_GNUC_AVAILABLE)
+#pragma GCC diagnostic push
+// status domains have no business being dynamically de-/allocated
+// and therefore don't need no virtual destructor
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
+template <status_enum Enum>
+class data_defined_status_domain_type : public system_error::status_code_domain
+{
+    template <class DomainType>
+    friend class system_error::status_code;
+    template <class StatusCode>
+    friend class system_error::detail::indirecting_domain;
+
+public:
+    using value_type = Enum;
+    using status_code_domain::string_ref;
+
+    using definition = status_enum_definition<value_type>;
+    using value_descriptor = status_enum_value_descriptor<value_type>;
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    static constexpr std::string_view uuid{definition::domain_id};
+
+    ~data_defined_status_domain_type() = default;
+    constexpr explicit data_defined_status_domain_type()
+        : status_code_domain(uuid.data(), _uuid_size<uuid.size()>{})
+    {
+    }
+
+    static constexpr auto get() noexcept -> status_code_domain const &;
+
+    [[nodiscard]] constexpr auto name() const noexcept -> string_ref override
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+        constexpr std::string_view domainName{definition::domain_name};
+        return string_ref(domainName.data(), domainName.size());
+    }
+
+    [[nodiscard]] constexpr auto payload_info() const noexcept
+            -> payload_info_t override
+    {
+        static_assert(alignof(Enum) <= alignof(status_code_domain *));
+        // NOLINTNEXTLINE(bugprone-sizeof-expression)
+        return {sizeof(Enum), sizeof(status_code_domain *) + sizeof(Enum),
+                alignof(status_code_domain *)};
+    }
+
+protected:
+#if 1
+    [[nodiscard]] static constexpr auto count_success_codes() noexcept
+            -> std::size_t
+    {
+        std::size_t numSuccessCodes = 0U;
+        for (value_descriptor const &descriptor : definition::values)
+        {
+            // check whether equivalence map contains errc::success
+            if (descriptor.equivalent == system_error::errc::success)
+            {
+                numSuccessCodes += 1U;
+            }
+        }
+        return numSuccessCodes;
+    }
+    static constexpr auto num_success_codes = count_success_codes();
+    struct success_codes_type
+    {
+        Enum values[num_success_codes == 0U ? 1U : num_success_codes];
+    };
+    [[nodiscard]] static constexpr auto extract_success_codes()
+            -> success_codes_type
+    {
+        success_codes_type codes{};
+        auto *outputIt = std::begin(codes.values);
+        if constexpr (num_success_codes > 0U)
+        {
+            for (value_descriptor const &descriptor : definition::values)
+            {
+                // check whether equivalence map contains errc::success
+                if (descriptor.equivalent == system_error::errc::success)
+                {
+                    // this is only const evaluated => no UB allowed anyway
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                    *outputIt++ = descriptor.value;
+                }
+            }
+        }
+        return codes;
+    }
+    static constexpr success_codes_type success_codes = extract_success_codes();
+#endif
+
+    [[nodiscard]] DPLX_CNCR_STATUS_CONSTEXPR auto
+    _do_failure(system_error::status_code<void> const &code) const noexcept
+            -> bool override
+    {
+        auto const &typedCode
+                = static_cast<data_defined_status_code<Enum> const &>(code);
+        auto &&value = typedCode.value();
+
+#if 1
+        if constexpr (num_success_codes > 0U)
+        {
+            // Does the success code list contain the given value?
+            for (auto const &descriptor : success_codes.values)
+            {
+                if (descriptor == value)
+                {
+                    return false;
+                }
+            }
+        }
+#else
+        constexpr std::span<value_descriptor const> descriptors(
+                definition::values);
+        for (value_descriptor const &descriptor : descriptors)
+        {
+            if (descriptor.value == value)
+            {
+                return descriptor.equivalent != system_error::errc::success;
+            }
+        }
+#endif
+        return true;
+    }
+
+    [[nodiscard]] DPLX_CNCR_STATUS_CONSTEXPR auto
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    _do_equivalent(system_error::status_code<void> const &self,
+                   system_error::status_code<void> const &other) const noexcept
+            -> bool override
+    {
+        auto const &typedSelf
+                = static_cast<data_defined_status_code<Enum> const &>(self);
+
+        // same domain => strict value comparison
+        if (other.domain() == *this)
+        {
+            auto const &typedOther
+                    = static_cast<data_defined_status_code<Enum> const &>(
+                            other);
+
+            return typedSelf.value() == typedOther.value();
+        }
+
+        // generic code domain => apply data defined equivalence mapping
+        if (other.domain() == system_error::generic_code_domain)
+        {
+            auto const &genericOther
+                    = static_cast<system_error::generic_code const &>(other);
+            auto &&selfValue = typedSelf.value();
+
+            // find matching descriptor
+            constexpr std::span<value_descriptor const> descriptors(
+                    definition::values);
+            for (value_descriptor const &descriptor : descriptors)
+            {
+                if (descriptor.value == selfValue)
+                {
+                    // check whether equivalence map contains the given code
+                    return descriptor.equivalent == genericOther.value();
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [[nodiscard]] DPLX_CNCR_STATUS_CONSTEXPR auto
+    _generic_code(system_error2::status_code<void> const &self) const noexcept
+            -> system_error::generic_code override
+    {
+        auto const &typedCode
+                = static_cast<data_defined_status_code<Enum> const &>(self);
+        auto &&value = typedCode.value();
+
+        // find matching descriptor
+        constexpr std::span<value_descriptor const> descriptors(
+                definition::values);
+        for (value_descriptor const &descriptor : descriptors)
+        {
+            if (descriptor.value == value)
+            {
+                return descriptor.equivalent;
+            }
+        }
+        // the given code can't be represented by the generic coding.
+        return system_error::errc::unknown;
+    }
+
+    [[nodiscard]] DPLX_CNCR_STATUS_CONSTEXPR auto
+    _do_message(system_error2::status_code<void> const &self) const noexcept
+            -> string_ref override
+    {
+        auto const &typedCode
+                = static_cast<data_defined_status_code<Enum> const &>(self);
+        auto &&value = typedCode.value();
+        constexpr std::span<value_descriptor const> descriptors(
+                definition::values);
+
+        // find matching descriptor
+        for (value_descriptor const &descriptor : descriptors)
+        {
+            if (descriptor.value == value)
+            {
+                return string_ref(descriptor.description.data(),
+                                  descriptor.description.size());
+            }
+        }
+
+        return string_ref("unknown error code value");
+    }
+
+    [[noreturn]] void _do_throw_exception(
+            system_error::status_code<void> const &code) const override
+    {
+        auto const &typedCode
+                = static_cast<data_defined_status_code<Enum> const &>(code);
+        throw system_error::status_error<data_defined_status_domain_type>(
+                typedCode);
+    }
+};
+
+// NOLINTEND(cppcoreguidelines-pro-type-static-cast-downcast)
+// NOLINTEND(cppcoreguidelines-virtual-class-destructor)
+
+#if defined(DPLX_COMP_GNUC_AVAILABLE)
+#pragma GCC diagnostic pop
+#endif
+
+template <status_enum Enum>
+inline constexpr data_defined_status_domain_type<Enum>
+        data_defined_status_domain{};
+
+template <status_enum Enum>
+inline constexpr auto data_defined_status_domain_type<Enum>::get() noexcept
+        -> status_code_domain const &
+{
+    return data_defined_status_domain<Enum>;
+}
+
+#if 0
+template <status_enum Enum>
+constexpr auto make_status_code(Enum c) noexcept
+        -> data_defined_status_code<Enum>
+{
+    return data_defined_status_code<Enum>(c);
+}
+#endif
+
+} // namespace dplx::cncr
+
+namespace SYSTEM_ERROR2_NAMESPACE
+{
+
+template <dplx::cncr::status_enum Enum>
+struct quick_status_code_from_enum<Enum>
+{
+    using code_type = dplx::cncr::data_defined_status_code<Enum>;
+};
+
+} // namespace SYSTEM_ERROR2_NAMESPACE
+
+#undef DPLX_CNCR_STATUS_CONSTEXPR

--- a/src/dplx/cncr/data_defined_status_domain.test.cpp
+++ b/src/dplx/cncr/data_defined_status_domain.test.cpp
@@ -1,0 +1,115 @@
+
+// Copyright Henrik Steffen Gaßmann 2019
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/cncr/data_defined_status_domain.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cncr_tests/test_utils.hpp>
+#include <status-code/quick_status_code_from_enum.hpp>
+
+namespace cncr_tests
+{
+enum class test_errc
+{
+    success = 0,
+    perm = 3,
+    other_success = 5,
+    not_implemented = 7,
+};
+// using dplx::cncr::make_status_code;
+
+namespace
+{
+
+} // namespace
+} // namespace cncr_tests
+
+template <>
+struct dplx::cncr::status_enum_definition<cncr_tests::test_errc>
+    : status_enum_definition_defaults<cncr_tests::test_errc>
+{
+    static constexpr char domain_id[]
+            = "{09E0ECBF-A737-454D-8633-17E733CDE15F}";
+    static constexpr char domain_name[] = "test-domain";
+
+    static constexpr value_descriptor values[] = {
+            {        code::success,           generic_errc::success,       "yay!"},
+            {           code::perm, generic_errc::permission_denied,      "oh no"},
+            {  code::other_success,           generic_errc::success,     "oh kay"},
+            {code::not_implemented,           generic_errc::unknown, "till later"},
+    };
+};
+
+namespace cncr_tests
+{
+
+using test_domain = dplx::cncr::data_defined_status_domain_type<test_errc>;
+using test_code = dplx::cncr::data_defined_status_code<test_errc>;
+
+TEST_CASE("test_errc can be converted to status_code")
+{
+    test_code c = test_errc::success;
+    CHECK(c.value() == test_errc::success);
+}
+
+TEST_CASE("data defined domain forwards the domain uuid")
+{
+    constexpr auto parsed = cncr::system_error::detail::parse_uuid_from_array(
+            cncr::status_enum_definition<test_errc>::domain_id);
+
+    CHECK(test_code::domain_type::get().id() == parsed);
+}
+
+TEST_CASE("data defined domain forwards the domain name")
+{
+    CHECK(std::string_view(test_code::domain_type::get().name().data())
+          == std::string_view(
+                  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                  cncr::status_enum_definition<test_errc>::domain_name));
+}
+
+TEST_CASE("data defined domain translates failure and success")
+{
+    CHECK(test_code(test_errc::success).success());
+    CHECK(test_code(test_errc::other_success).success());
+
+    CHECK(test_code(test_errc::perm).failure());
+    CHECK(test_code(test_errc::not_implemented).failure());
+}
+
+TEST_CASE("data defined domain allows generic comparisons")
+{
+    using errc = cncr::system_error::errc;
+
+    auto &&[code, equivalent] = GENERATE(table<test_errc, errc>({
+            {        test_errc::success,           errc::success},
+            {           test_errc::perm, errc::permission_denied},
+            {  test_errc::other_success,           errc::success},
+            {test_errc::not_implemented,           errc::unknown},
+    }));
+
+    CHECK(test_code(code) == equivalent);
+    CHECK(equivalent == test_code(code));
+}
+
+TEST_CASE("data defined domain returns the correct description")
+{
+    using enum test_errc;
+    using namespace std::string_view_literals;
+
+    auto &&[code, description] = GENERATE(table<test_errc, std::string_view>({
+            {        success,       "yay!"sv},
+            {           perm,      "oh no"sv},
+            {  other_success,     "oh kay"sv},
+            {not_implemented, "till later"sv},
+    }));
+
+    CHECK(std::string_view(test_code(code).message().data()) == description);
+}
+
+} // namespace cncr_tests

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,6 +1,6 @@
 {
     "default-registry": {
         "kind": "builtin",
-        "baseline": "8b62d95a81afcb9efe74bebeb62f04c1e0e2a003"
+        "baseline": "6ca56aeb457f033d344a7106cb3f9f1abf8f4e98"
     }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
     "version-semver": "0.0.0-alpha.6",
     "homepage": "https://github.com/deeplex/concrete",
     "dependencies": [
+        "status-code"
     ],
     "features": {
         "tests": {


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
Defining status domains requires quite a bit of boilerplate code which is very similar for simple status codes based on enumerations. In these cases we simply don't need the generality provided by the `status-code` library.


### Solution Sketch
Add a status domain template which adapts status enumerations described by an extension point.
