### PR TITLE
Allow cancelling of scope guard execution

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: lukka/get-cmake@v3.22.2
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.22.6
 
       - name: Initialize vcpkg
         uses: lukka/run-vcpkg@v10
@@ -69,7 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: lukka/get-cmake@v3.22.2
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.22.6
 
       - name: Initialize vcpkg
         uses: lukka/run-vcpkg@v10

--- a/src/dplx/scope_guard.hpp
+++ b/src/dplx/scope_guard.hpp
@@ -8,32 +8,161 @@
 #pragma once
 
 #include <exception>
-#include <utility>
+#include <type_traits>
 
 namespace dplx
 {
 
-template <typename Fn>
-struct scope_guard
+template <typename EF>
+class scope_exit
 {
-    inline scope_guard(Fn &&fn)
-        : mFn(std::forward<Fn>(fn))
+    EF mExitFunction;
+    bool mActive;
+
+public:
+    ~scope_exit()
     {
-    }
-    inline ~scope_guard() noexcept
-    {
-        mFn();
+        if (mActive)
+        {
+            mExitFunction();
+        }
     }
 
-private:
-    Fn mFn;
+    scope_exit(scope_exit &&other) noexcept(
+            std::is_nothrow_copy_constructible_v<EF>)
+        : mExitFunction(other.mExitFunction)
+        , mActive(other.mActive)
+    {
+        other.mActive = false;
+    }
+    scope_exit(scope_exit &&other) noexcept requires
+            std::is_nothrow_move_constructible_v<EF>
+        : mExitFunction(static_cast<EF &&>(other.mExitFunction))
+        , mActive(other.mActive)
+    {
+        other.mActive = false;
+    }
+
+    // the following constructors defend against move confusion with constraints
+    // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_exit>
+                && std::is_constructible_v<EF, Fn>
+                && std::is_nothrow_constructible_v<EF, Fn>)
+    // clang-format on
+    scope_exit(Fn &&fn)
+    noexcept
+        : mExitFunction(static_cast<Fn &&>(fn))
+        , mActive(true)
+    {
+    }
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_exit>
+                && std::is_constructible_v<EF, Fn>   
+                && !std::is_nothrow_constructible_v<EF, Fn>  
+                && std::is_nothrow_constructible_v<EF, std::remove_reference_t<Fn> &>)
+    // clang-format on
+    scope_exit(Fn &&fn)
+    noexcept
+        : mExitFunction(fn)
+        , mActive(true)
+    {
+    }
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_exit>
+                && std::is_constructible_v<EF, Fn>
+                && !std::is_nothrow_constructible_v<EF, Fn> 
+                && !std::is_nothrow_constructible_v<EF, std::remove_reference_t<Fn> &>)
+    // clang-format on
+    scope_exit(Fn &&fn)
+    try : mExitFunction(fn), mActive(true)
+    {
+    }
+    catch (...)
+    {
+        fn();
+        throw;
+    }
+
+    // NOLINTEND(bugprone-forwarding-reference-overload)
+
+    void release() noexcept
+    {
+        mActive = false;
+    }
 };
+template <class EF>
+scope_exit(EF) -> scope_exit<EF>;
+
+template <typename EF>
+class scope_guard
+{
+    EF mExitFunction;
+
+public:
+    ~scope_guard()
+    {
+        mExitFunction();
+    }
+
+    // the following constructors defend against move confusion with constraints
+    // NOLINTBEGIN(bugprone-forwarding-reference-overload)
+
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_guard>
+                && std::is_constructible_v<EF, Fn>
+                && std::is_nothrow_constructible_v<EF, Fn>)
+    // clang-format on
+    scope_guard(Fn &&fn)
+    noexcept
+        : mExitFunction(static_cast<Fn &&>(fn))
+    {
+    }
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_guard>
+                && std::is_constructible_v<EF, Fn>   
+                && !std::is_nothrow_constructible_v<EF, Fn>  
+                && std::is_nothrow_constructible_v<EF, std::remove_reference_t<Fn> &>)
+    // clang-format on
+    scope_guard(Fn &&fn)
+    noexcept
+        : mExitFunction(fn)
+    {
+    }
+    template <class Fn>
+        // clang-format off
+        requires (!std::is_same_v<std::remove_cvref_t<Fn>, scope_guard>
+                && std::is_constructible_v<EF, Fn>
+                && !std::is_nothrow_constructible_v<EF, Fn> 
+                && !std::is_nothrow_constructible_v<EF, std::remove_reference_t<Fn> &>)
+    // clang-format on
+    scope_guard(Fn &&fn)
+    try : mExitFunction(fn)
+    {
+    }
+    catch (...)
+    {
+        fn();
+        throw;
+    }
+
+    // NOLINTEND(bugprone-forwarding-reference-overload)
+};
+template <class EF>
+scope_guard(EF) -> scope_guard<EF>;
 
 template <typename Fn>
-struct exception_scope_guard
+    requires std::is_nothrow_move_constructible_v<Fn>
+struct [[deprecated]] exception_scope_guard
 {
-    inline exception_scope_guard(Fn &&fn)
-        : mFn(std::forward<Fn>(fn))
+    inline exception_scope_guard(Fn &&fn) noexcept
+        : mFn(static_cast<Fn &&>(fn))
         , mUncaughtExceptions(std::uncaught_exceptions())
     {
     }

--- a/src/dplx/scope_guard.test.cpp
+++ b/src/dplx/scope_guard.test.cpp
@@ -6,3 +6,145 @@
 //           https://www.boost.org/LICENSE_1_0.txt)
 
 #include "dplx/scope_guard.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cncr_tests/test_utils.hpp>
+
+namespace cncr_tests
+{
+
+TEST_CASE("scope_exit is constructible from a lambda rvalue")
+{
+    int called = 0;
+    {
+        scope_exit subject = [&called]
+        {
+            called += 1;
+        };
+    }
+
+    CHECK(called == 1);
+}
+
+TEST_CASE("scope_exit is constructible from a lambda lvalue")
+{
+    auto exitFunction = [] {
+    };
+    scope_exit subject = exitFunction;
+}
+
+struct callable_noexcept_move
+{
+    int *called{nullptr};
+
+    callable_noexcept_move() = default;
+    callable_noexcept_move(callable_noexcept_move &&) noexcept = default;
+
+    callable_noexcept_move(int *out) noexcept
+        : called{out}
+    {
+    }
+
+    void operator()() const noexcept
+    {
+        if (called != nullptr)
+        {
+            *called += 1;
+        }
+    }
+};
+static_assert(
+        std::is_nothrow_constructible_v<scope_exit<callable_noexcept_move>,
+                                        callable_noexcept_move>);
+
+struct callable_throwing_copy
+{
+    int *called{nullptr};
+
+    callable_throwing_copy() = default;
+    callable_throwing_copy(callable_throwing_copy const &)
+    {
+    }
+
+    callable_throwing_copy(int *out) noexcept
+        : called{out}
+    {
+    }
+
+    void operator()() const noexcept
+    {
+        if (called != nullptr)
+        {
+            *called += 1;
+        }
+    }
+};
+
+struct callable_throwing_move_with_copy
+{
+    int *called{nullptr};
+
+    callable_throwing_move_with_copy() = default;
+    callable_throwing_move_with_copy(
+            callable_throwing_move_with_copy const &) noexcept
+    {
+    }
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    callable_throwing_move_with_copy(callable_throwing_move_with_copy &&)
+    {
+    }
+
+    callable_throwing_move_with_copy(int *out) noexcept
+        : called{out}
+    {
+    }
+
+    void operator()() const noexcept
+    {
+        if (called != nullptr)
+        {
+            *called += 1;
+        }
+    }
+};
+static_assert(std::is_nothrow_constructible_v<
+              scope_exit<callable_throwing_move_with_copy>,
+              callable_throwing_move_with_copy>);
+
+TEST_CASE("scope_exit is constructible from a throwing rvalue move")
+{
+    scope_exit subject = callable_throwing_move_with_copy{};
+}
+
+TEST_CASE("scope_exit is constructible from a throwing rvalue copy")
+{
+    scope_exit subject = callable_throwing_copy{};
+}
+
+TEST_CASE("scope_exit is constructible from a throwing lvalue")
+{
+    callable_throwing_copy exitFunction{};
+    scope_exit subject = exitFunction;
+}
+
+TEST_CASE("scope_exit can be moved and still executes once")
+{
+    int numCalls = 0;
+    {
+        scope_exit subject1 = callable_noexcept_move{&numCalls};
+        scope_exit subject2 = std::move(subject1);
+    }
+    CHECK(numCalls == 1);
+}
+
+TEST_CASE("scope_exit::release cancels execution of the finalization logic")
+{
+    int numCalls = 0;
+    {
+        scope_exit subject = callable_noexcept_move{&numCalls};
+        subject.release();
+    }
+    CHECK(numCalls == 0);
+}
+
+} // namespace cncr_tests


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->
Make cleanup / finalization logic management more flexible and integrated.

Resolves #12


### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
Implement the `scope_exit` type proposed by the [Library Fundamentals TS v3] which matches our desired properties and can be substituted with the standard implementation in the future.

[Library Fundamentals TS v3]: https://cplusplus.github.io/fundamentals-ts/v3.html#scopeguard.exit