### PR TITLE
Make `status_enum_definition` SFINAE friendly

### DIFF
--- a/src/dplx/cncr/data_defined_status_domain.hpp
+++ b/src/dplx/cncr/data_defined_status_domain.hpp
@@ -53,14 +53,20 @@ struct status_enum_definition_defaults
 };
 
 template <typename Enum>
-    requires std::default_initializable<Enum> && std::movable<
-            Enum> && std::equality_comparable<Enum>
-struct status_enum_definition;
+struct status_enum_definition
+{
+};
 
 // clang-format off
 template <typename T>
 concept status_enum
-        = !system_error::is_status_code<T>::value
+        = requires {
+            typename status_enum_definition<T>::code;
+            requires std::same_as<T, typename status_enum_definition<T>::code>;
+            requires std::default_initializable<T>;
+            requires std::movable<T>;
+            requires std::equality_comparable<T>;
+        }
         && std::constructible_from<
                 std::span<status_enum_value_descriptor<T> const>,
                 decltype(status_enum_definition<T>::values)>


### PR DESCRIPTION

<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->
Prevent GCC getting confused about `outcome::result<T>`'s constructability.

Resolves #21


### Solution Sketch
Provide an empty class primary template definition for `status_enum_definition` and move `Enum` type constraints to the `status_enum` concept.

